### PR TITLE
Adiciona possibilidade de execução do processamento de tweets para diferentes backends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ help:
 	@echo "\t$(b)feed-update-data$(s)\tAtualiza dados para as tabelas para o Banco de dados"
 	@echo "\t$(b)feed-drop-tables$(s)\tAtenção: Dropa as Tabelas para o Banco de dados"
 	@echo "\t$(b)r-shell$(s)\t\t\tAbre uma instância bash dentro do container do r-leggo-twitter"
-	@echo "\t$(b)r-export-data$(s)\t\tExecuta o processamento de dados (fetchers) para Proposições, parlamentares e tweets"
+	@echo "\t$(b)r-export-data url="https://api.leggo.org.br"$(s)\t\tExecuta o processamento de dados (fetchers) para Proposições, parlamentares e tweets"
 	@echo "\t$(b)r-export-data-db-format$(s)\tExecuta o processamentos dos dados para o formato do BD"
 	@echo "\t$(b)feed-do-migrations$(s)\tAtualiza as tabelas para o Banco de dados"
 .PHONY: help
@@ -40,7 +40,8 @@ r-shell:
 	docker exec -it r-leggo-twitter bash
 .PHONY: r-shell
 r-export-data:
-	docker exec -it r-leggo-twitter bash -c "Rscript /leggo-twitter-dados/code/export_data.R"
+	if [ -z "$(url)" ]; then echo "Insira uma url válida para API do Parlametria"; \
+	else echo "\nUsando a API: "$(url); docker exec -it r-leggo-twitter bash -c "Rscript /leggo-twitter-dados/code/export_data.R -u $(url)"; fi
 .PHONY: r-export-data
 r-export-data-db-format:
 	docker exec -it r-leggo-twitter bash -c "Rscript /leggo-twitter-dados/code/processor/export_data_to_db_format.R"

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Nesta seção apresentaremos dois comandos úteis para o processamento dos dados
 1. A primeira etapa do processamento envolve capturar, processar e salvar os dados de proposições, parlamentares e tweets. Para isto é possível executar o comando:
 
 ```
-make r-export-data
+make r-export-data url=https://api.leggo.org.br
 ```
 
 Todos os dados serão salvos na pasta `data/` conforme o módulo ao qual pertence.

--- a/code/export_data.R
+++ b/code/export_data.R
@@ -1,5 +1,24 @@
 library(tidyverse)
 
+if(!require(optparse)){
+  install.packages("optparse")
+  suppressWarnings(suppressMessages(library(optparse)))
+}
+
+args = commandArgs(trailingOnly=TRUE)
+
+message("Use --help para mais informações\n")
+
+option_list = list(
+  make_option(c("-u", "--url"), type="character", default="https://api.leggo.org.br", 
+              help="url da api do parlametria [default= %default]", metavar="character")
+) 
+
+opt_parser = OptionParser(option_list=option_list)
+opt = parse_args(opt_parser)
+
+api_url <- opt$url
+
 message("Recupera, processa e exporta dados de parlamentares, proposições e tweets")
 
 source(here::here("code/parlamentares/export_parlamentares.R"))

--- a/code/parlamentares/export_parlamentares.R
+++ b/code/parlamentares/export_parlamentares.R
@@ -12,19 +12,31 @@ message("Use --help para mais informações\n")
 
 option_list = list(
   make_option(c("-o", "--out"), type="character", default=here::here("data/parlamentares/parlamentares.csv"), 
-              help="nome do arquivo de saída [default= %default]", metavar="character")
+              help="nome do arquivo de saída [default= %default]", metavar="character"),
+  make_option(c("-u", "--url"), type="character", default="https://dev.api.leggo.org.br", 
+              help="url da api do parlametria [default= %default]", metavar="character")
 ) 
 
 opt_parser = OptionParser(option_list=option_list)
 opt = parse_args(opt_parser)
 
 saida <- opt$out
+api_url <- opt$url
 
-message("Iniciando processamento de parlamentares...")
-message("Baixando dados...")
-parlamentares <- fetch_parlamentares_em_exercicio()
 
-message(paste0("Salvando o resultado em ", saida))
-write_csv(parlamentares, saida)
+export_parlamentares <- function(api_url = "https://dev.api.leggo.org.br", 
+                                 saida = here::here("data/parlamentares/parlamentares.csv")) {
+  message("Iniciando processamento de parlamentares...")
+  message("Baixando dados...")
+  parlamentares <- fetch_parlamentares_em_exercicio(api_url)
+  
+  message(paste0("Salvando o resultado em ", saida))
+  write_csv(parlamentares, saida)
+  
+  message("Concluído!")
+}
 
-message("Concluído!")
+if (!interactive()) {
+  export_parlamentares(api_url, saida)
+}
+

--- a/code/parlamentares/fetcher_parlamentares.R
+++ b/code/parlamentares/fetcher_parlamentares.R
@@ -1,12 +1,14 @@
 #' @title Baixa os parlamentares em execício
 #' @description Retorna os parlamentares que estão em exercício
+#' @param api_url URL da api do Parlametria. (Não incluir a '/' ao final do domínio).
 #' @return Dataframe com informações dos parlamentares em exercício,
 #' como id, casa, nome, partido e uf.
-fetch_parlamentares_em_exercicio <- function() {
+fetch_parlamentares_em_exercicio <- function(api_url = "https://dev.api.leggo.org.br") {
   library(tidyverse)
   
   url <-
-    "https://dev.api.leggo.org.br/entidades/parlamentares/exercicio"
+    paste0(api_url, 
+           "/entidades/parlamentares/exercicio")
   
   parlamentares <- RCurl::getURL(url, .encoding = "UTF-8") %>%
     jsonlite::fromJSON()

--- a/code/proposicoes/export_proposicoes.R
+++ b/code/proposicoes/export_proposicoes.R
@@ -12,19 +12,30 @@ message("Use --help para mais informações\n")
 
 option_list = list(
   make_option(c("-o", "--out"), type="character", default=here::here("data/proposicoes/proposicoes.csv"), 
-              help="nome do arquivo de saída [default= %default]", metavar="character")
+              help="nome do arquivo de saída [default= %default]", metavar="character"),
+  make_option(c("-u", "--url"), type="character", default="https://dev.api.leggo.org.br", 
+              help="url da api do parlametria [default= %default]", metavar="character")
 ) 
 
 opt_parser = OptionParser(option_list=option_list)
 opt = parse_args(opt_parser)
 
 saida <- opt$out
+api_url <- opt$url
 
-message("Iniciando processamento de proposições...")
-message("Baixando dados...")
-proposicoes <- fetch_proposicoes_todas_agendas()
+export_proposicoes <- function(api_url = "https://dev.api.leggo.org.br", 
+                               saida = here::here("data/proposicoes/proposicoes.csv")) {
+  message("Iniciando processamento de proposições...")
+  message("Baixando dados...")
+  proposicoes <- fetch_proposicoes_todas_agendas(api_url)
+  
+  message(paste0("Salvando o resultado em ", saida))
+  write_csv(proposicoes, saida)
+  
+  message("Concluído!")
+}
 
-message(paste0("Salvando o resultado em ", saida))
-write_csv(proposicoes, saida)
+if (!interactive()) {
+  export_proposicoes(api_url, saida)
+}
 
-message("Concluído!")

--- a/code/proposicoes/fetcher_proposicoes.R
+++ b/code/proposicoes/fetcher_proposicoes.R
@@ -3,15 +3,18 @@
 #' Leggo com essa agenda.
 #' @param agenda Agenda de interesse (obs: sem acentos e espaços,
 #' ex: reforma-tributaria)
+#' @param api_url URL da api do Parlametria. (Não incluir a '/' ao final do domínio).
 #' @return Dataframe com informações das proposições de uma agenda.
 fetch_proposicoes_by_agenda <-
-  function(agenda = "congresso-remoto") {
+  function(agenda = "congresso-remoto",
+           api_url = "https://dev.api.leggo.org.br") {
     library(tidyverse)
 
     print(paste0("Baixando proposições da agenda ", agenda, "..."))
     
     url <-
-      paste0("https://api.leggo.org.br/proposicoes/?interesse=",
+      paste0(api_url, 
+             "/proposicoes/?interesse=",
              agenda)
     
     df <-
@@ -43,15 +46,16 @@ fetch_proposicoes_by_agenda <-
 
 #' @title Baixa as proposições para todas as agendas do Leggo Proposições
 #' @description Retorna as proposições monitoradas pelas agendas do Leggo
+#' @param api_url URL da api do Parlametria. (Não incluir a '/' ao final do domínio).
 #' @return Dataframe com informações das proposições.
-fetch_proposicoes_todas_agendas <- function() {
+fetch_proposicoes_todas_agendas <- function(api_url = "https://dev.api.leggo.org.br") {
   library(tidyverse)
   
-  agendas <- RCurl::getURL("https://api.leggo.org.br/interesses") %>% 
+  agendas <- RCurl::getURL(paste0(api_url, "/interesses")) %>% 
     jsonlite::fromJSON() %>% 
     select(interesse)
   
   proposicoes <- purrr::map_df(agendas$interesse, 
-                               ~ fetch_proposicoes_by_agenda(.x))
+                               ~ fetch_proposicoes_by_agenda(.x, api_url))
   return(proposicoes)
 }

--- a/code/relatorias/export_relatorias.R
+++ b/code/relatorias/export_relatorias.R
@@ -12,19 +12,31 @@ message("Use --help para mais informações\n")
 
 option_list = list(
   make_option(c("-o", "--out"), type="character", default=here::here("data/relatorias/relatorias.csv"), 
-              help="nome do arquivo de saída [default= %default]", metavar="character")
+              help="nome do arquivo de saída [default= %default]", metavar="character"),
+  make_option(c("-u", "--url"), type="character", default="https://dev.api.leggo.org.br", 
+              help="url da api do parlametria [default= %default]", metavar="character")
 ) 
 
 opt_parser = OptionParser(option_list=option_list)
 opt = parse_args(opt_parser)
 
 saida <- opt$out
+api_url <- opt$url
 
-message("Iniciando processamento de relatorias...")
-message("Baixando dados...")
-relatorias <- fetch_relatores_proposicoes_todas_agendas()
+export_relatorias <- function(api_url = "https://dev.api.leggo.org.br",
+                              saida = here::here("data/relatorias/relatorias.csv")) {
+  message("Iniciando processamento de relatorias...")
+  message("Baixando dados...")
+  relatorias <- fetch_relatores_proposicoes_todas_agendas(api_url)
+  
+  message(paste0("Salvando o resultado em ", saida))
+  write_csv(relatorias, saida)
+  
+  message("Concluído!")
+}
 
-message(paste0("Salvando o resultado em ", saida))
-write_csv(relatorias, saida)
+if (!interactive()) {
+  export_relatorias(api_url, saida)
+}
 
-message("Concluído!")
+

--- a/code/relatorias/fetcher_relatorias.R
+++ b/code/relatorias/fetcher_relatorias.R
@@ -20,13 +20,19 @@ fetch_relatores_proposicoes_by_agenda <-
       RCurl::getURL(url, .encoding = "UTF-8") %>%
       jsonlite::fromJSON()
     
-    relatores <- df %>%
-      select(id_parlamentar_parlametria = relator_id_parlametria,
-             id_proposicao = id_leggo,
-             casa) %>% 
-      distinct()
-    
-    return(relatores)
+    if (!is.null(nrow(df))) {
+      relatores <- df %>%
+        select(id_parlamentar_parlametria = relator_id_parlametria,
+               id_proposicao = id_leggo,
+               casa) %>% 
+        distinct()
+      
+      return(relatores)
+      
+    } else {
+      
+      return(tibble())
+    }
   }
 
 #' @title Recupera as relatorias das proposições de todas as agendas

--- a/code/relatorias/fetcher_relatorias.R
+++ b/code/relatorias/fetcher_relatorias.R
@@ -2,15 +2,18 @@
 #' @description Recupera todos os relatores das proposições de uma agenda
 #' @param agenda Agenda de interesse (obs: sem acentos e espaços,
 #' ex: reforma-tributaria)
+#' @param api_url URL da api do Parlametria. (Não incluir a '/' ao final do domínio).
 #' @return Dataframe com informações dos relatores das proposições de uma agenda.
 fetch_relatores_proposicoes_by_agenda <-
-  function(agenda = "congresso-remoto") {
+  function(agenda = "congresso-remoto",
+           api_url = "https://dev.api.leggo.org.br") {
     library(tidyverse)
     
     print(paste0("Baixando relatores de proposições da agenda ", agenda, "..."))
     
     url <-
-      paste0("https://api.leggo.org.br/relatores/?interesse=",
+      paste0(api_url, 
+             "/relatores/?interesse=",
              agenda)
     
     df <-
@@ -28,16 +31,17 @@ fetch_relatores_proposicoes_by_agenda <-
 
 #' @title Recupera as relatorias das proposições de todas as agendas
 #' @description Retorna relatorias de proposições de todas as agendas
+#' @param api_url URL da api do Parlametria. (Não incluir a '/' ao final do domínio).
 #' @return Dataframe com informações dos relatores das proposições de todas as agendas.
-fetch_relatores_proposicoes_todas_agendas <- function() {
+fetch_relatores_proposicoes_todas_agendas <- function(api_url = "https://dev.api.leggo.org.br") {
   library(tidyverse)
   
-  agendas <- RCurl::getURL("http://dev.api.leggo.org.br/interesses") %>% 
+  agendas <- RCurl::getURL(paste0(api_url, "/interesses")) %>% 
     jsonlite::fromJSON() %>% 
     select(interesse)
   
   relatores <- purrr::map_df(agendas$interesse, 
-                               ~ fetch_relatores_proposicoes_by_agenda(.x)) %>% 
+                               ~ fetch_relatores_proposicoes_by_agenda(.x, api_url)) %>% 
     distinct()
   return(relatores)
 }

--- a/code/tweets/export_tweets.R
+++ b/code/tweets/export_tweets.R
@@ -12,7 +12,9 @@ message("Use --help para mais informações\n")
 
 option_list = list(
   make_option(c("-o", "--out"), type="character", default=here::here("data/tweets/tweets.csv"), 
-              help="nome do arquivo de saída [default= %default]", metavar="character")
+              help="nome do arquivo de saída [default= %default]", metavar="character"),
+  make_option(c("-u", "--url"), type="character", default="https://dev.api.leggo.org.br", 
+              help="url da api do parlametria [default= %default]", metavar="character")
 ) 
 
 opt_parser = OptionParser(option_list=option_list)
@@ -20,11 +22,17 @@ opt = parse_args(opt_parser)
 
 saida <- opt$out
 
-message("Iniciando processamento de tweets...")
-message("Baixando dados...")
-tweets <- fetch_tweets()
+export_tweets <- function(saida = here::here("data/tweets/tweets.csv")) {
+  message("Iniciando processamento de tweets...")
+  message("Baixando dados...")
+  tweets <- fetch_tweets()
+  
+  message(paste0("Salvando o resultado em ", saida))
+  write_csv(tweets, saida)
+  
+  message("Concluído!")
+}
 
-message(paste0("Salvando o resultado em ", saida))
-write_csv(tweets, saida)
-
-message("Concluído!")
+if (!interactive()) {
+  export_tweets(saida)
+}


### PR DESCRIPTION
## Mudanças
- Modifica Makefile para considerar o endereço da url do backend que será usado para processamento dos tweets.
Casos de teste:
make r-export-data url=https://api.leggo.org.br
make r-export-data url=https://dev.api.leggo.org.br
make r-export-data url=http://agorapi:8000 (as vezes é necessário conectar os containers: docker network connect compose_default r-leggo-twitter)


