### PR TITLE
Adiciona opção de gerar dados de tweets sobre proposições vindas de csv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ r-shell:
 .PHONY: r-shell
 r-export-data:
 	if [ -z "$(url)" ]; then echo "Insira uma url válida para API do Parlametria"; \
-	else echo "\nUsando a API: "$(url); docker exec -it r-leggo-twitter bash -c "Rscript /leggo-twitter-dados/code/export_data.R -u $(url) -p $(props_csv)"; fi
+	else echo "\nUsando a API: "$(url); docker exec -it r-leggo-twitter bash -c "Rscript /leggo-twitter-dados/code/export_data.R -u $(url)"; fi
 .PHONY: r-export-data
 r-export-data-db-format:
 	docker exec -it r-leggo-twitter bash -c "Rscript /leggo-twitter-dados/code/processor/export_data_to_db_format.R"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ help:
 	@echo "\t$(b)feed-update-data$(s)\tAtualiza dados para as tabelas para o Banco de dados"
 	@echo "\t$(b)feed-drop-tables$(s)\tAtenção: Dropa as Tabelas para o Banco de dados"
 	@echo "\t$(b)r-shell$(s)\t\t\tAbre uma instância bash dentro do container do r-leggo-twitter"
-	@echo "\t$(b)r-export-data url="https://api.leggo.org.br"$(s)\t\tExecuta o processamento de dados (fetchers) para Proposições, parlamentares e tweets"
+	@echo "\t$(b)r-export-data url="https://api.leggo.org.br" props_csv=<path>$(s)\t\tExecuta o processamento de dados (fetchers) para Proposições, parlamentares e tweets"
 	@echo "\t$(b)r-export-data-db-format$(s)\tExecuta o processamentos dos dados para o formato do BD"
 	@echo "\t$(b)feed-do-migrations$(s)\tAtualiza as tabelas para o Banco de dados"
 .PHONY: help
@@ -41,7 +41,7 @@ r-shell:
 .PHONY: r-shell
 r-export-data:
 	if [ -z "$(url)" ]; then echo "Insira uma url válida para API do Parlametria"; \
-	else echo "\nUsando a API: "$(url); docker exec -it r-leggo-twitter bash -c "Rscript /leggo-twitter-dados/code/export_data.R -u $(url)"; fi
+	else echo "\nUsando a API: "$(url); docker exec -it r-leggo-twitter bash -c "Rscript /leggo-twitter-dados/code/export_data.R -u $(url) -p $(props_csv)"; fi
 .PHONY: r-export-data
 r-export-data-db-format:
 	docker exec -it r-leggo-twitter bash -c "Rscript /leggo-twitter-dados/code/processor/export_data_to_db_format.R"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ help:
 	@echo "\t$(b)feed-update-data$(s)\tAtualiza dados para as tabelas para o Banco de dados"
 	@echo "\t$(b)feed-drop-tables$(s)\tAtenção: Dropa as Tabelas para o Banco de dados"
 	@echo "\t$(b)r-shell$(s)\t\t\tAbre uma instância bash dentro do container do r-leggo-twitter"
-	@echo "\t$(b)r-export-data url="https://api.leggo.org.br" props_csv=<path>$(s)\t\tExecuta o processamento de dados (fetchers) para Proposições, parlamentares e tweets"
+	@echo "\t$(b)r-export-data url="https://api.leggo.org.br"$(s)\t\tExecuta o processamento de dados (fetchers) para Proposições, parlamentares e tweets"
 	@echo "\t$(b)r-export-data-db-format$(s)\tExecuta o processamentos dos dados para o formato do BD"
 	@echo "\t$(b)feed-do-migrations$(s)\tAtualiza as tabelas para o Banco de dados"
 .PHONY: help

--- a/code/export_data.R
+++ b/code/export_data.R
@@ -12,7 +12,7 @@ message("Use --help para mais informações\n")
 option_list = list(
   make_option(c("-u", "--url"), type="character", default="https://api.leggo.org.br", 
               help="url da api do parlametria [default= %default]"),
-  make_option(c("-p", "--prop"), type="character", default=NULL, 
+  make_option(c("-p", "--prop"), type="character", default="", 
               help="caminho para o csv de proposições [default= %default]")
 )
 

--- a/code/export_data.R
+++ b/code/export_data.R
@@ -11,16 +11,18 @@ message("Use --help para mais informações\n")
 
 option_list = list(
   make_option(c("-u", "--url"), type="character", default="https://api.leggo.org.br", 
-              help="url da api do parlametria [default= %default]", metavar="character")
-) 
+              help="url da api do parlametria [default= %default]"),
+  make_option(c("-p", "--prop"), type="character", default=NULL, 
+              help="caminho para o csv de proposições [default= %default]")
+)
 
 opt_parser = OptionParser(option_list=option_list)
 opt = parse_args(opt_parser)
 
 api_url <- opt$url
+proposicoes_datapath <- opt$prop
 
 message("Recupera, processa e exporta dados de parlamentares, proposições e tweets")
-
 source(here::here("code/parlamentares/export_parlamentares.R"))
 source(here::here("code/proposicoes/export_proposicoes.R"))
 source(here::here("code/tweets/export_tweets.R"))

--- a/code/parlamentares/export_parlamentares.R
+++ b/code/parlamentares/export_parlamentares.R
@@ -14,7 +14,10 @@ option_list = list(
   make_option(c("-o", "--out"), type="character", default=here::here("data/parlamentares/parlamentares.csv"), 
               help="nome do arquivo de saída [default= %default]", metavar="character"),
   make_option(c("-u", "--url"), type="character", default="https://dev.api.leggo.org.br", 
-              help="url da api do parlametria [default= %default]", metavar="character")
+              help="url da api do parlametria [default= %default]", metavar="character"),
+  make_option(c("-p", "--prop"), type="character", default=NULL, 
+              help="caminho para o csv de proposições [default= %default]")
+  
 ) 
 
 opt_parser = OptionParser(option_list=option_list)

--- a/code/proposicoes/export_proposicoes.R
+++ b/code/proposicoes/export_proposicoes.R
@@ -29,7 +29,7 @@ export_proposicoes <- function(api_url = "https://dev.api.leggo.org.br",
                                proposicoes_datapath = NULL,
                                saida = here::here("data/proposicoes/proposicoes.csv")) {
   message("Iniciando processamento de proposições...")
-  if (is.null(proposicoes_datapath)) {
+  if (is.null(proposicoes_datapath) || proposicoes_datapath == "") {
     message("Baixando dados...")
     source(here::here("code/proposicoes/fetcher_proposicoes.R"))
     proposicoes <- fetch_proposicoes_todas_agendas(api_url = api_url)

--- a/code/proposicoes/export_proposicoes.R
+++ b/code/proposicoes/export_proposicoes.R
@@ -1,5 +1,4 @@
 library(tidyverse)
-source(here::here("code/proposicoes/fetcher_proposicoes.R"))
 
 if(!require(optparse)){
   install.packages("optparse")
@@ -14,7 +13,9 @@ option_list = list(
   make_option(c("-o", "--out"), type="character", default=here::here("data/proposicoes/proposicoes.csv"), 
               help="nome do arquivo de saída [default= %default]", metavar="character"),
   make_option(c("-u", "--url"), type="character", default="https://dev.api.leggo.org.br", 
-              help="url da api do parlametria [default= %default]", metavar="character")
+              help="url da api do parlametria [default= %default]", metavar="character"),
+  make_option(c("-p", "--prop"), type="character", default=NULL, 
+              help="caminho para o csv de proposições [default= %default]")
 ) 
 
 opt_parser = OptionParser(option_list=option_list)
@@ -22,12 +23,20 @@ opt = parse_args(opt_parser)
 
 saida <- opt$out
 api_url <- opt$url
+proposicoes_datapath <- opt$prop
 
 export_proposicoes <- function(api_url = "https://dev.api.leggo.org.br", 
+                               proposicoes_datapath = NULL,
                                saida = here::here("data/proposicoes/proposicoes.csv")) {
   message("Iniciando processamento de proposições...")
-  message("Baixando dados...")
-  proposicoes <- fetch_proposicoes_todas_agendas(api_url)
+  if (is.null(proposicoes_datapath)) {
+    message("Baixando dados...")
+    source(here::here("code/proposicoes/fetcher_proposicoes.R"))
+    proposicoes <- fetch_proposicoes_todas_agendas(api_url = api_url)
+  } else {
+    source(here::here("code/proposicoes/process_proposicoes.R"))
+    proposicoes <- processa_proposicoes(proposicoes_datapath)
+  }
   
   message(paste0("Salvando o resultado em ", saida))
   write_csv(proposicoes, saida)
@@ -36,6 +45,6 @@ export_proposicoes <- function(api_url = "https://dev.api.leggo.org.br",
 }
 
 if (!interactive()) {
-  export_proposicoes(api_url, saida)
+  export_proposicoes(api_url, proposicoes_datapath, saida)
 }
 

--- a/code/proposicoes/process_proposicoes.R
+++ b/code/proposicoes/process_proposicoes.R
@@ -1,0 +1,48 @@
+#' @title Processa temas
+#' @description Realiza o processamento de temas, criando um slug sem acentos, espaços, etc.
+#' @param tema Tema a ser processado
+#' @return Tema processado, sem acentos ou espaços.
+#' @example
+#' tema_slug <- .processa_tema("Primeira infância; Educação")
+.processa_tema <- function(tema) {
+  tema_processado <- tema %>%
+    tolower() %>%
+    iconv(., from="UTF-8", to="ASCII//TRANSLIT") %>%
+    gsub(x = ., " ", "-")
+  
+  return(tema_processado)
+}
+
+#' @title Processa proposições
+#' @description Realiza o processamento das proposições provenientes de csv
+#' (formato igual ao da planilha de uma agenda)
+#' @param proposicoes_datapath Caminho para o csv de proposições
+#' @return Dataframe com campos padronizados.
+processa_proposicoes <- function(proposicoes_datapath) {
+  library(tidyverse)
+  
+  proposicoes <- read_csv(proposicoes_datapath) %>%
+    rowwise(.) %>% 
+    mutate(id_proposicao = digest::digest(
+      paste0(id_camara , " ", id_senado),
+      algo = "md5",
+      serialize = F
+    )) %>%
+    ungroup() %>% 
+    mutate(temas_slug = .processa_tema(tema)) %>%
+    mutate(casa = if_else(!is.na(id_camara), "camara", "senado")) %>% 
+    mutate(interesse_slug = NA,
+           interesse_nome = NA,
+           casa_origem = NA) %>%
+    select(id_proposicao,
+           interesse_slug,
+           interesse_nome,
+           temas_nome = tema,
+           temas_slug,
+           sigla = proposicao,
+           casa,
+           casa_origem)
+  
+  return(proposicoes)
+  
+}

--- a/code/relatorias/export_relatorias.R
+++ b/code/relatorias/export_relatorias.R
@@ -14,7 +14,9 @@ option_list = list(
   make_option(c("-o", "--out"), type="character", default=here::here("data/relatorias/relatorias.csv"), 
               help="nome do arquivo de saída [default= %default]", metavar="character"),
   make_option(c("-u", "--url"), type="character", default="https://dev.api.leggo.org.br", 
-              help="url da api do parlametria [default= %default]", metavar="character")
+              help="url da api do parlametria [default= %default]", metavar="character"),
+  make_option(c("-p", "--prop"), type="character", default=NULL, 
+              help="caminho para o csv de proposições [default= %default]")
 ) 
 
 opt_parser = OptionParser(option_list=option_list)

--- a/code/tweets/export_tweets.R
+++ b/code/tweets/export_tweets.R
@@ -14,7 +14,9 @@ option_list = list(
   make_option(c("-o", "--out"), type="character", default=here::here("data/tweets/tweets.csv"), 
               help="nome do arquivo de saída [default= %default]", metavar="character"),
   make_option(c("-u", "--url"), type="character", default="https://dev.api.leggo.org.br", 
-              help="url da api do parlametria [default= %default]", metavar="character")
+              help="url da api do parlametria [default= %default]", metavar="character"),
+  make_option(c("-p", "--prop"), type="character", default=NULL, 
+              help="caminho para o csv de proposições [default= %default]")
 ) 
 
 opt_parser = OptionParser(option_list=option_list)


### PR DESCRIPTION
- Se nenhum caminho for passado no parâmetro **-p** do script `export_data.R`, os scripts baixarão os dados das proposições passadas por API; Caso contrário, as proposições do csv serão consideradas.