### PR TITLE
Fix error of lib RPostgres not being installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM rocker/tidyverse:3.6.2
 WORKDIR /leggo-twitter-dados
 
 RUN R -e "install.packages(c('here', 'optparse', 'RCurl'), repos='http://cran.rstudio.com/')"
-RUN R -e "install.packages(c('RPostgres'), repos='http://cran.rstudio.com/')"
+RUN R -e "install.packages(c('RPostgres'))"
 
 COPY ./code /leggo-twitter-dados/code


### PR DESCRIPTION
A biblioteca RPostgres não estava sendo instalada corretamente:

```
Execution halted
ERROR: lazy loading failed for package ‘RPostgres’
* removing ‘/usr/local/lib/R/site-library/RPostgres’

The downloaded source packages are in
	‘/tmp/RtmpUoP8bv/downloaded_packages’
Warning messages:
1: In install.packages(c("RPostgres"), repos = "http://cran.rstudio.com/") :
  installation of package ‘hms’ had non-zero exit status
2: In install.packages(c("RPostgres"), repos = "http://cran.rstudio.com/") :
  installation of package ‘RPostgres’ had non-zero exit status
```

Esse PR corrige a instalação dessa lib.
