### PR TITLE
Corrige pipeline quebrado em relação a URL tem todos os arquivos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ help:
 	@echo "\t$(b)feed-update-data$(s)\tAtualiza dados para as tabelas para o Banco de dados"
 	@echo "\t$(b)feed-drop-tables$(s)\tAtenção: Dropa as Tabelas para o Banco de dados"
 	@echo "\t$(b)r-shell$(s)\t\t\tAbre uma instância bash dentro do container do r-leggo-twitter"
-	@echo "\t$(b)r-export-data url="https://api.leggo.org.br"$(s)\t\tExecuta o processamento de dados (fetchers) para Proposições, parlamentares e tweets"
+	@echo "\t$(b)r-export-data url="https://api.parlametria.org.br"$(s)\t\tExecuta o processamento de dados (fetchers) para Proposições, parlamentares e tweets"
 	@echo "\t$(b)r-export-data-db-format$(s)\tExecuta o processamentos dos dados para o formato do BD"
 	@echo "\t$(b)feed-do-migrations$(s)\tAtualiza as tabelas para o Banco de dados"
 	@echo "\t$(b)r-export-tweets-to-process$(s)\tRecupera os tweets do banco de dados que ainda não foram processados e salva em csv"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Nesta seção apresentaremos dois comandos úteis para o processamento dos dados
 1. A primeira etapa do processamento envolve capturar, processar e salvar os dados de proposições, parlamentares e tweets. Para isto é possível executar o comando:
 
 ```
-make r-export-data url=https://api.leggo.org.br
+make r-export-data url=https://api.parlametria.org.br
 ```
 
 Todos os dados serão salvos na pasta `data/` conforme o módulo ao qual pertence.

--- a/code/export_data.R
+++ b/code/export_data.R
@@ -10,7 +10,7 @@ args = commandArgs(trailingOnly=TRUE)
 message("Use --help para mais informações\n")
 
 option_list = list(
-  make_option(c("-u", "--url"), type="character", default="https://api.leggo.org.br", 
+  make_option(c("-u", "--url"), type="character", default="https://api.parlametria.org.br", 
               help="url da api do parlametria [default= %default]"),
   make_option(c("-p", "--prop"), type="character", default="", 
               help="caminho para o csv de proposições [default= %default]")

--- a/code/parlamentares/export_parlamentares.R
+++ b/code/parlamentares/export_parlamentares.R
@@ -13,7 +13,7 @@ message("Use --help para mais informações\n")
 option_list = list(
   make_option(c("-o", "--out"), type="character", default=here::here("data/parlamentares/parlamentares.csv"), 
               help="nome do arquivo de saída [default= %default]", metavar="character"),
-  make_option(c("-u", "--url"), type="character", default="https://dev.api.leggo.org.br", 
+  make_option(c("-u", "--url"), type="character", default="https://dev.api.parlametria.org.br", 
               help="url da api do parlametria [default= %default]", metavar="character"),
   make_option(c("-p", "--prop"), type="character", default=NULL, 
               help="caminho para o csv de proposições [default= %default]")
@@ -26,8 +26,7 @@ opt = parse_args(opt_parser)
 saida <- opt$out
 api_url <- opt$url
 
-
-export_parlamentares <- function(api_url = "https://dev.api.leggo.org.br", 
+export_parlamentares <- function(api_url = "https://dev.api.parlametria.org.br", 
                                  saida = here::here("data/parlamentares/parlamentares.csv")) {
   message("Iniciando processamento de parlamentares...")
   message("Baixando dados...")

--- a/code/parlamentares/export_parlamentares.R
+++ b/code/parlamentares/export_parlamentares.R
@@ -13,7 +13,7 @@ message("Use --help para mais informações\n")
 option_list = list(
   make_option(c("-o", "--out"), type="character", default=here::here("data/parlamentares/parlamentares.csv"), 
               help="nome do arquivo de saída [default= %default]", metavar="character"),
-  make_option(c("-u", "--url"), type="character", default="https://dev.api.parlametria.org.br", 
+  make_option(c("-u", "--url"), type="character", default="https://api.parlametria.org.br", 
               help="url da api do parlametria [default= %default]", metavar="character"),
   make_option(c("-p", "--prop"), type="character", default=NULL, 
               help="caminho para o csv de proposições [default= %default]")
@@ -26,7 +26,7 @@ opt = parse_args(opt_parser)
 saida <- opt$out
 api_url <- opt$url
 
-export_parlamentares <- function(api_url = "https://dev.api.parlametria.org.br", 
+export_parlamentares <- function(api_url = "https://api.parlametria.org.br", 
                                  saida = here::here("data/parlamentares/parlamentares.csv")) {
   message("Iniciando processamento de parlamentares...")
   message("Baixando dados...")

--- a/code/parlamentares/fetcher_parlamentares.R
+++ b/code/parlamentares/fetcher_parlamentares.R
@@ -3,7 +3,7 @@
 #' @param api_url URL da api do Parlametria. (Não incluir a '/' ao final do domínio).
 #' @return Dataframe com informações dos parlamentares em exercício,
 #' como id, casa, nome, partido e uf.
-fetch_parlamentares_em_exercicio <- function(api_url = "https://dev.api.parlametria.org.br") {
+fetch_parlamentares_em_exercicio <- function(api_url = "https://api.parlametria.org.br") {
   library(tidyverse)
   
   url <-

--- a/code/parlamentares/fetcher_parlamentares.R
+++ b/code/parlamentares/fetcher_parlamentares.R
@@ -3,7 +3,7 @@
 #' @param api_url URL da api do Parlametria. (Não incluir a '/' ao final do domínio).
 #' @return Dataframe com informações dos parlamentares em exercício,
 #' como id, casa, nome, partido e uf.
-fetch_parlamentares_em_exercicio <- function(api_url = "https://dev.api.leggo.org.br") {
+fetch_parlamentares_em_exercicio <- function(api_url = "https://dev.api.parlametria.org.br") {
   library(tidyverse)
   
   url <-

--- a/code/proposicoes/export_proposicoes.R
+++ b/code/proposicoes/export_proposicoes.R
@@ -12,7 +12,7 @@ message("Use --help para mais informações\n")
 option_list = list(
   make_option(c("-o", "--out"), type="character", default=here::here("data/proposicoes/proposicoes.csv"), 
               help="nome do arquivo de saída [default= %default]", metavar="character"),
-  make_option(c("-u", "--url"), type="character", default="https://dev.api.parlametria.org.br", 
+  make_option(c("-u", "--url"), type="character", default="https://api.parlametria.org.br", 
               help="url da api do parlametria [default= %default]", metavar="character"),
   make_option(c("-p", "--prop"), type="character", default=NULL, 
               help="caminho para o csv de proposições [default= %default]")
@@ -25,7 +25,7 @@ saida <- opt$out
 api_url <- opt$url
 proposicoes_datapath <- opt$prop
 
-export_proposicoes <- function(api_url = "https://dev.api.parlametria.org.br", 
+export_proposicoes <- function(api_url = "https://api.parlametria.org.br", 
                                proposicoes_datapath = NULL,
                                saida = here::here("data/proposicoes/proposicoes.csv")) {
   message("Iniciando processamento de proposições...")

--- a/code/proposicoes/export_proposicoes.R
+++ b/code/proposicoes/export_proposicoes.R
@@ -12,7 +12,7 @@ message("Use --help para mais informações\n")
 option_list = list(
   make_option(c("-o", "--out"), type="character", default=here::here("data/proposicoes/proposicoes.csv"), 
               help="nome do arquivo de saída [default= %default]", metavar="character"),
-  make_option(c("-u", "--url"), type="character", default="https://dev.api.leggo.org.br", 
+  make_option(c("-u", "--url"), type="character", default="https://dev.api.parlametria.org.br", 
               help="url da api do parlametria [default= %default]", metavar="character"),
   make_option(c("-p", "--prop"), type="character", default=NULL, 
               help="caminho para o csv de proposições [default= %default]")
@@ -25,7 +25,7 @@ saida <- opt$out
 api_url <- opt$url
 proposicoes_datapath <- opt$prop
 
-export_proposicoes <- function(api_url = "https://dev.api.leggo.org.br", 
+export_proposicoes <- function(api_url = "https://dev.api.parlametria.org.br", 
                                proposicoes_datapath = NULL,
                                saida = here::here("data/proposicoes/proposicoes.csv")) {
   message("Iniciando processamento de proposições...")

--- a/code/proposicoes/fetcher_proposicoes.R
+++ b/code/proposicoes/fetcher_proposicoes.R
@@ -7,7 +7,7 @@
 #' @return Dataframe com informações das proposições de uma agenda.
 fetch_proposicoes_by_agenda <-
   function(agenda = "transparencia-e-integridade",
-           api_url = "https://dev.api.parlametria.org.br") {
+           api_url = "https://api.parlametria.org.br") {
     library(tidyverse)
 
     print(paste0("Baixando proposições da agenda ", agenda, "..."))
@@ -83,7 +83,7 @@ fetch_proposicoes_by_agenda <-
 #' @description Retorna as proposições monitoradas pelas agendas do Leggo
 #' @param api_url URL da api do Parlametria. (Não incluir a '/' ao final do domínio).
 #' @return Dataframe com informações das proposições.
-fetch_proposicoes_todas_agendas <- function(api_url = "https://dev.api.parlametria.org.br") {
+fetch_proposicoes_todas_agendas <- function(api_url = "https://api.parlametria.org.br") {
   library(tidyverse)
   
   agendas <- RCurl::getURL(paste0(api_url, "/interesses")) %>% 

--- a/code/proposicoes/fetcher_proposicoes.R
+++ b/code/proposicoes/fetcher_proposicoes.R
@@ -7,7 +7,7 @@
 #' @return Dataframe com informações das proposições de uma agenda.
 fetch_proposicoes_by_agenda <-
   function(agenda = "transparencia-e-integridade",
-           api_url = "https://dev.api.leggo.org.br") {
+           api_url = "https://dev.api.parlametria.org.br") {
     library(tidyverse)
 
     print(paste0("Baixando proposições da agenda ", agenda, "..."))
@@ -83,7 +83,7 @@ fetch_proposicoes_by_agenda <-
 #' @description Retorna as proposições monitoradas pelas agendas do Leggo
 #' @param api_url URL da api do Parlametria. (Não incluir a '/' ao final do domínio).
 #' @return Dataframe com informações das proposições.
-fetch_proposicoes_todas_agendas <- function(api_url = "https://dev.api.leggo.org.br") {
+fetch_proposicoes_todas_agendas <- function(api_url = "https://dev.api.parlametria.org.br") {
   library(tidyverse)
   
   agendas <- RCurl::getURL(paste0(api_url, "/interesses")) %>% 

--- a/code/relatorias/export_relatorias.R
+++ b/code/relatorias/export_relatorias.R
@@ -13,7 +13,7 @@ message("Use --help para mais informações\n")
 option_list = list(
   make_option(c("-o", "--out"), type="character", default=here::here("data/relatorias/relatorias.csv"), 
               help="nome do arquivo de saída [default= %default]", metavar="character"),
-  make_option(c("-u", "--url"), type="character", default="https://dev.api.leggo.org.br", 
+  make_option(c("-u", "--url"), type="character", default="https://dev.api.parlametria.org.br", 
               help="url da api do parlametria [default= %default]", metavar="character"),
   make_option(c("-p", "--prop"), type="character", default=NULL, 
               help="caminho para o csv de proposições [default= %default]")
@@ -25,7 +25,7 @@ opt = parse_args(opt_parser)
 saida <- opt$out
 api_url <- opt$url
 
-export_relatorias <- function(api_url = "https://dev.api.leggo.org.br",
+export_relatorias <- function(api_url = "https://dev.api.parlametria.org.br",
                               saida = here::here("data/relatorias/relatorias.csv")) {
   message("Iniciando processamento de relatorias...")
   message("Baixando dados...")

--- a/code/relatorias/export_relatorias.R
+++ b/code/relatorias/export_relatorias.R
@@ -13,7 +13,7 @@ message("Use --help para mais informações\n")
 option_list = list(
   make_option(c("-o", "--out"), type="character", default=here::here("data/relatorias/relatorias.csv"), 
               help="nome do arquivo de saída [default= %default]", metavar="character"),
-  make_option(c("-u", "--url"), type="character", default="https://dev.api.parlametria.org.br", 
+  make_option(c("-u", "--url"), type="character", default="https://api.parlametria.org.br", 
               help="url da api do parlametria [default= %default]", metavar="character"),
   make_option(c("-p", "--prop"), type="character", default=NULL, 
               help="caminho para o csv de proposições [default= %default]")
@@ -25,7 +25,7 @@ opt = parse_args(opt_parser)
 saida <- opt$out
 api_url <- opt$url
 
-export_relatorias <- function(api_url = "https://dev.api.parlametria.org.br",
+export_relatorias <- function(api_url = "https://api.parlametria.org.br",
                               saida = here::here("data/relatorias/relatorias.csv")) {
   message("Iniciando processamento de relatorias...")
   message("Baixando dados...")

--- a/code/relatorias/fetcher_relatorias.R
+++ b/code/relatorias/fetcher_relatorias.R
@@ -6,7 +6,7 @@
 #' @return Dataframe com informações dos relatores das proposições de uma agenda.
 fetch_relatores_proposicoes_by_agenda <-
   function(agenda = "congresso-remoto",
-           api_url = "https://dev.api.parlametria.org.br") {
+           api_url = "https://api.parlametria.org.br") {
     library(tidyverse)
     
     print(paste0("Baixando relatores de proposições da agenda ", agenda, "..."))
@@ -39,7 +39,7 @@ fetch_relatores_proposicoes_by_agenda <-
 #' @description Retorna relatorias de proposições de todas as agendas
 #' @param api_url URL da api do Parlametria. (Não incluir a '/' ao final do domínio).
 #' @return Dataframe com informações dos relatores das proposições de todas as agendas.
-fetch_relatores_proposicoes_todas_agendas <- function(api_url = "https://dev.api.parlametria.org.br") {
+fetch_relatores_proposicoes_todas_agendas <- function(api_url = "https://api.parlametria.org.br") {
   library(tidyverse)
   
   agendas <- RCurl::getURL(paste0(api_url, "/interesses")) %>% 

--- a/code/relatorias/fetcher_relatorias.R
+++ b/code/relatorias/fetcher_relatorias.R
@@ -6,7 +6,7 @@
 #' @return Dataframe com informações dos relatores das proposições de uma agenda.
 fetch_relatores_proposicoes_by_agenda <-
   function(agenda = "congresso-remoto",
-           api_url = "https://dev.api.leggo.org.br") {
+           api_url = "https://dev.api.parlametria.org.br") {
     library(tidyverse)
     
     print(paste0("Baixando relatores de proposições da agenda ", agenda, "..."))
@@ -39,7 +39,7 @@ fetch_relatores_proposicoes_by_agenda <-
 #' @description Retorna relatorias de proposições de todas as agendas
 #' @param api_url URL da api do Parlametria. (Não incluir a '/' ao final do domínio).
 #' @return Dataframe com informações dos relatores das proposições de todas as agendas.
-fetch_relatores_proposicoes_todas_agendas <- function(api_url = "https://dev.api.leggo.org.br") {
+fetch_relatores_proposicoes_todas_agendas <- function(api_url = "https://dev.api.parlametria.org.br") {
   library(tidyverse)
   
   agendas <- RCurl::getURL(paste0(api_url, "/interesses")) %>% 

--- a/code/tweets/export_tweets.R
+++ b/code/tweets/export_tweets.R
@@ -13,7 +13,7 @@ message("Use --help para mais informações\n")
 option_list = list(
   make_option(c("-o", "--out"), type="character", default=here::here("data/tweets/tweets.csv"), 
               help="nome do arquivo de saída [default= %default]", metavar="character"),
-  make_option(c("-u", "--url"), type="character", default="https://dev.api.parlametria.org.br", 
+  make_option(c("-u", "--url"), type="character", default="https://api.parlametria.org.br", 
               help="url da api do parlametria [default= %default]", metavar="character"),
   make_option(c("-p", "--prop"), type="character", default=NULL, 
               help="caminho para o csv de proposições [default= %default]")

--- a/code/tweets/export_tweets.R
+++ b/code/tweets/export_tweets.R
@@ -13,7 +13,7 @@ message("Use --help para mais informações\n")
 option_list = list(
   make_option(c("-o", "--out"), type="character", default=here::here("data/tweets/tweets.csv"), 
               help="nome do arquivo de saída [default= %default]", metavar="character"),
-  make_option(c("-u", "--url"), type="character", default="https://dev.api.leggo.org.br", 
+  make_option(c("-u", "--url"), type="character", default="https://dev.api.parlametria.org.br", 
               help="url da api do parlametria [default= %default]", metavar="character"),
   make_option(c("-p", "--prop"), type="character", default=NULL, 
               help="caminho para o csv de proposições [default= %default]")

--- a/code/usuarios/export_usuarios.R
+++ b/code/usuarios/export_usuarios.R
@@ -13,7 +13,7 @@ message("Use --help para mais informações\n")
 option_list = list(
   make_option(c("-o", "--out"), type="character", default=here::here("data/usuarios/usuarios.csv"), 
               help="nome do arquivo de saída [default= %default]", metavar="character"),
-  make_option(c("-u", "--url"), type="character", default="https://dev.api.leggo.org.br", 
+  make_option(c("-u", "--url"), type="character", default="https://dev.api.parlametria.org.br", 
               help="url da api do parlametria [default= %default]", metavar="character")
   
 ) 

--- a/code/usuarios/export_usuarios.R
+++ b/code/usuarios/export_usuarios.R
@@ -13,7 +13,7 @@ message("Use --help para mais informações\n")
 option_list = list(
   make_option(c("-o", "--out"), type="character", default=here::here("data/usuarios/usuarios.csv"), 
               help="nome do arquivo de saída [default= %default]", metavar="character"),
-  make_option(c("-u", "--url"), type="character", default="https://dev.api.parlametria.org.br", 
+  make_option(c("-u", "--url"), type="character", default="https://api.parlametria.org.br", 
               help="url da api do parlametria [default= %default]", metavar="character")
   
 ) 


### PR DESCRIPTION
# Descrição

Foi atualizado  as URLs:

`https://api.parlametria.org.br`
~`https://dev.api.parlametria.org.br`~

Em todos os arquivos, tanto para o `Makefile` e scripts `R`. 

# Issue

Closes #39 